### PR TITLE
use file('') instead of a textConnection

### DIFF
--- a/R/renderReactLog.R
+++ b/R/renderReactLog.R
@@ -9,6 +9,9 @@ render_reactlog <- function(log, session_token = NULL, time = TRUE) {
   html <- paste(readLines(template_file, warn = FALSE), collapse = "\r\n")
 
   tmpfile <- file("")
+  on.exit({
+    close(tmpfile)
+  })
   write_reactlog(log, tmpfile, session_token)
 
   fixed_sub <- function(...) {

--- a/R/renderReactLog.R
+++ b/R/renderReactLog.R
@@ -8,18 +8,18 @@ render_reactlog <- function(log, session_token = NULL, time = TRUE) {
   template_file <- system.file("reactlog.html", package = "reactlog")
   html <- paste(readLines(template_file, warn = FALSE), collapse = "\r\n")
 
-  tc <- textConnection(NULL, "w")
-  on.exit(close(tc))
-  write_reactlog(log, tc, session_token)
-  cat("\n", file = tc)
-  flush(tc)
+  tmpfile <- file("")
+  write_reactlog(log, tmpfile, session_token)
 
   fixed_sub <- function(...) {
     sub(..., fixed = TRUE)
   }
 
+  # incomplete final line warning
+  lines <- readLines(tmpfile, warn = FALSE, encoding = "UTF-8")
+
   html <- fixed_sub(
-    "__DATA__", paste(textConnectionValue(tc), collapse = "\r\n"),
+    "__DATA__", paste(lines, collapse = "\r\n"),
     fixed_sub(
       "__TIME__", paste0("\"", time, "\""),
       fixed_sub(


### PR DESCRIPTION
Speed before:
![screen shot 2018-12-10 at 4 42 50 pm](https://user-images.githubusercontent.com/93231/49811698-c8452680-fd31-11e8-9a7e-78eaeade8384.png)

Speed after:
![screen shot 2018-12-10 at 4 43 09 pm](https://user-images.githubusercontent.com/93231/49811704-cb401700-fd31-11e8-90eb-99817f8fda21.png)
