### PR TITLE
warn to unix users that the latest preview of ide will not launch reactlog

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,24 @@
+# there is no package an only exists within the rstudio ide
+utils::globalVariables("RStudio.Version")
+
+.onAttach <- function(...) {
+  # if on unix
+  if (.Platform$OS.type == "unix") {
+    # if in RStudio IDE
+    if (identical(.Platform$GUI, "RStudio")) {
+      # if on a release version 1.2.1303
+      try({
+        # this function exists as a loaded namespace within the ide...
+        # there is no direct package for it
+        if (RStudio.Version()$version == "1.2.1303") {
+          packageStartupMessage(
+            "There is a known bug within unix systems",
+            " on RStudio pre-release v1.2.1303.",
+            "\nPlease install the latest RStudio daily build to display",
+            " the reactlog using the `Ctrl+F3` keybinding."
+          )
+        } # end is preview version
+      }) # end try
+    } # end if RStudio
+  } # end if unix
+}


### PR DESCRIPTION
Displays a message to unix users on IDE preview v1.2.1303 that they keybindings will not work and to install the daily build.

The try statement is used as to avoid a dep on `rstudioapi` and just call the function that is in the namespace `tools:rstudio`.  This is near the top of the search path, so it should be found without directly stating the namespace name.