### PR TITLE
Use workflow_dispatch instead of cron schedule

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,8 +7,8 @@ on:
     branches: [main, rc-**]
   pull_request:
     branches: [main]
-  schedule:
-    - cron: '0 8 * * 1' # every monday
+# Triggered remotely from rstudio/shinycoreci.
+  workflow_dispatch:
 
 name: Package checks
 


### PR DESCRIPTION
Remove the weekly cron trigger (every Monday at 08:00) and add workflow_dispatch so the workflow can be triggered manually or remotely (e.g., from rstudio/shinycoreci). Keeps existing branch and pull_request triggers intact.
